### PR TITLE
Naughty: Correctly set default timeout values

### DIFF
--- a/lib/naughty/notification.lua
+++ b/lib/naughty/notification.lua
@@ -1044,11 +1044,9 @@ local function create(args)
     end
 
     -- Because otherwise the setter logic would not be executed
-    if n._private.timeout then
-        n:set_timeout(n._private.timeout
-            or (n.preset and n.preset.timeout)
-            or cst.config.timeout
-        )
+    local timeout = n._private.timeout or (n.preset and n.preset.timeout) or cst.config.defaults.timeout
+    if timeout then
+        n:set_timeout(timeout)
     end
 
     return n

--- a/tests/test-naughty-legacy.lua
+++ b/tests/test-naughty-legacy.lua
@@ -1264,6 +1264,26 @@ table.insert(steps, function()
     return true
 end)
 
+-- Check that a timeout value was set up for non-legacy notification
+table.insert(steps, function()
+    assert(naughty.has_display_handler == true)
+
+    naughty.config.preset.normal.timeout = 24
+    naughty.config.defaults.timeout = 42
+    local n = naughty.notification {
+        message = "bar",
+    }
+
+    -- Normal preset timeout value should be used
+    assert(n._private.timeout == 24)
+
+    naughty.config.preset.normal.timeout = nil
+    -- Default timeout value should be used
+    assert(n._private.timeout == 42)
+
+    return true
+end)
+
 -- Make sure it isn't possible to remove default variables (#3145).
 table.insert(steps, function()
     naughty.config.defaults = {fake_variable = 24}


### PR DESCRIPTION
Notifications stayed indefinitively with the box layout by default, even
if we had defined the timeout in the defaults table or use a preset when
creating a notification.